### PR TITLE
Setup Auth Emulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ next-env.d.ts
 # firebase logs
 **/firebase-debug.log
 **/firestore-debug.log
+
+#firebase
+.firebaserc

--- a/firebase.json
+++ b/firebase.json
@@ -1,10 +1,14 @@
 {
   "emulators": {
     "firestore": {
-      "port": 3240 
+      "port": 3240
     },
     "ui": {
       "enabled": true
-    }
+    },
+    "auth": {
+      "port": 9099
+    },
+    "singleProjectMode": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "fix": "eslint src test --fix",
     "clean": "gts clean",
     "coverage-command": "vitest run * --coverage",
-    "coverage": "firebase --project demo emulators:exec --only firestore \"npm run coverage-command\"",
+    "coverage": "firebase --project demo emulators:exec --only auth,firestore \"npm run coverage-command\"",
     "test-command": "vitest --test-timeout=0",
-    "test": "firebase --project demo emulators:exec --only firestore \"npm run test-command\"",
+    "test": "firebase --project demo emulators:exec --only auth,firestore \"npm run test-command\"",
     "prepare": "husky"
   },
   "engines": {

--- a/test/utils/database.util.ts
+++ b/test/utils/database.util.ts
@@ -1,9 +1,14 @@
 import {Document, FirestoreDatabase, IDatabase} from 'lib/data';
 import {Firestore, connectFirestoreEmulator} from 'firebase/firestore';
+import {connectAuthEmulator, Auth} from 'firebase/auth';
 
 export function getLocalFirebase(db: Firestore): IDatabase {
   connectFirestoreEmulator(db, 'localhost', 3240);
   return new FirestoreDatabase(db);
+}
+
+export function getLocalAuth(auth: Auth) {
+  connectAuthEmulator(auth, 'http://localhost:9099');
 }
 
 export async function clearCollection(database: IDatabase, collection: string) {


### PR DESCRIPTION
## Why / Feature

> https://trello.com/c/xLRASOTi

## What's Changed in the Code

> Add function in `test/utils` to initialize auth emulator
> add auth emulator to `firebase emulators:exec` command in `npm run test` and `npm run coverage`
> add auth emulator to `firebase.json` config file

## How can I check if it works?

> When a test runs, check if firebase starts the auth emulator properly (it should say something like `emulators: Starting emulators: auth, firestore` and have no errors)

## How did I test?
> Ran `npm run test` and checked if the auth emulator was being run