### PR TITLE
Fix auth to use cookies based on firebase tokens

### DIFF
--- a/src/app/auth.tsx
+++ b/src/app/auth.tsx
@@ -1,8 +1,8 @@
 'use server';
-import {User, UserType} from 'lib/data';
+import {DataModel, DefaultModel, User, UserType} from 'lib/data';
 import {redirect} from 'next/navigation';
 import {normalizeID} from 'lib/util';
-import {AuthModel} from 'lib/data/auth_model';
+import {AuthModel, IAuthModel} from 'lib/data/auth_model';
 
 function createUser(
   name: string,
@@ -46,15 +46,15 @@ export async function createUserAction(
   email: string,
   total_budget: number,
   password: string,
-  TESTING_FLAG = false
+  TESTING_FLAG = false,
+  auth: IAuthModel = AuthModel,
+  dm: DataModel = DefaultModel
 ): Promise<{message: string} | void> {
   const emailNorm = normalizeID(email);
-  const auth = AuthModel;
-
   try {
     const user_type = await deterUserType(email);
     const user = createUser(name, emailNorm, total_budget, user_type);
-    await auth.createUser(emailNorm, password, user);
+    await auth.createUser(emailNorm, password, user, dm);
   } catch (error) {
     return {
       message: error!.toString(),
@@ -67,9 +67,9 @@ export async function createUserAction(
 }
 
 export async function signOutAction(
-  TESTING_FLAG = false
+  TESTING_FLAG = false,
+  auth: IAuthModel = AuthModel
 ): Promise<{message: string} | void> {
-  const auth = AuthModel;
   try {
     auth.signOut();
   } catch (error) {
@@ -85,10 +85,10 @@ export async function signOutAction(
 export async function signInAction(
   email: string,
   password: string,
-  TESTING_FLAG = false
+  TESTING_FLAG = false,
+  auth: IAuthModel = AuthModel
 ): Promise<{message: string} | void> {
   const emailNorm = normalizeID(email);
-  const auth = AuthModel;
   try {
     await auth.signIn(emailNorm, password);
   } catch (error) {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,5 +1,4 @@
 'use server';
-import {verifySession} from 'app/dal';
 import {Dashboard} from './dashboard';
 import {DataModel, Database} from 'lib/data';
 import {SGADashboard} from './sgaDashboard';
@@ -14,13 +13,10 @@ export default async function Page() {
   const dataModel = new DataModel(db);
   const auth = AuthModel;
 
-  // const session = await verifySession();
   try {
     const userId = await auth.getSignedInUser();
-    const user = await dataModel.getUser('grintech@studentorg.grinnell.edu');
+    const user = await dataModel.getUser(userId);
     const isSGA = userIsSGA(user);
-    console.log(`User id from session is: ${userId}`);
-
     return isSGA ? (
       <SGADashboard user={user} dataModel={dataModel} />
     ) : (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,11 +1,11 @@
 'use server';
-import { Dashboard } from './dashboard';
-import { DataModel, Database } from 'lib/data';
-import { SGADashboard } from './sgaDashboard';
-import { userIsSGA } from 'lib/data/utils';
-import { revalidatePath } from 'next/cache';
-import { AuthModel } from 'lib/data/auth_model';
-import { redirect } from 'next/navigation';
+import {Dashboard} from './dashboard';
+import {DataModel, Database} from 'lib/data';
+import {SGADashboard} from './sgaDashboard';
+import {userIsSGA} from 'lib/data/utils';
+import {revalidatePath} from 'next/cache';
+import {AuthModel} from 'lib/data/auth_model';
+import {redirect} from 'next/navigation';
 
 export default async function Page() {
   revalidatePath('/dashboard');

--- a/src/app/logIn.tsx
+++ b/src/app/logIn.tsx
@@ -4,8 +4,18 @@ import {Alert, Button, Checkbox, Label, TextInput} from 'flowbite-react';
 import {SignUp} from './signUp';
 import {signInAction} from './auth';
 import {FormEvent, FormEventHandler, useState} from 'react';
+import {IAuthModel} from 'lib/data/auth_model';
+import {DataModel} from 'lib/data';
 
-export function LogIn({TESTING_FLAG}: {TESTING_FLAG?: boolean}) {
+export function LogIn({
+  TESTING_FLAG,
+  TEST_AUTH,
+  TEST_MODEL,
+}: {
+  TESTING_FLAG?: boolean;
+  TEST_AUTH?: IAuthModel;
+  TEST_MODEL?: DataModel;
+}) {
   const [showErrorAlert, setShowErrorAlert] = useState(false);
   const [showSuccessAlert, setShowSuccessAlert] = useState(false);
   const [errorMessage, setError] = useState('');
@@ -21,7 +31,12 @@ export function LogIn({TESTING_FLAG}: {TESTING_FLAG?: boolean}) {
       e.currentTarget.elements.namedItem('password') as HTMLInputElement
     ).value;
 
-    const result = await signInAction(email, password, TESTING_FLAG);
+    let result;
+    if (TESTING_FLAG) {
+      result = await signInAction(email, password, TESTING_FLAG, TEST_AUTH);
+    } else {
+      result = await signInAction(email, password);
+    }
     if (result) {
       setShowErrorAlert(true);
       setError(result.message);
@@ -72,7 +87,11 @@ export function LogIn({TESTING_FLAG}: {TESTING_FLAG?: boolean}) {
           Log In
         </Button>
       </form>
-      <SignUp TESTING_FLAG={TESTING_FLAG} />
+      <SignUp
+        TESTING_FLAG={TESTING_FLAG}
+        TEST_AUTH={TEST_AUTH}
+        TEST_MODEL={TEST_MODEL}
+      />
       {showErrorAlert && (
         <Alert
           className="max-w-md"

--- a/src/app/logIn.tsx
+++ b/src/app/logIn.tsx
@@ -4,8 +4,6 @@ import {Alert, Button, Checkbox, Label, TextInput} from 'flowbite-react';
 import {SignUp} from './createAcc';
 import {signInAction} from './auth';
 import {FormEvent, FormEventHandler, useState} from 'react';
-import {error} from 'console';
-import {errorMonitor} from 'events';
 
 export function ComponentLog() {
   const [showErrorAlert, setShowErrorAlert] = useState(false);

--- a/src/app/signUp.tsx
+++ b/src/app/signUp.tsx
@@ -3,8 +3,18 @@
 import {Alert, Button, Label, Modal, TextInput} from 'flowbite-react';
 import {FormEvent, FormEventHandler, useState} from 'react';
 import {createUserAction} from './auth';
+import {DataModel} from 'lib/data';
+import {IAuthModel} from 'lib/data/auth_model';
 
-export function SignUp({TESTING_FLAG}: {TESTING_FLAG?: boolean}) {
+export function SignUp({
+  TESTING_FLAG,
+  TEST_AUTH,
+  TEST_MODEL,
+}: {
+  TESTING_FLAG?: boolean;
+  TEST_AUTH?: IAuthModel;
+  TEST_MODEL?: DataModel;
+}) {
   const [openModal, setOpenModal] = useState(false);
   const [showErrorAlert, setShowErrorAlert] = useState(false);
   const [showSuccessAlert, setShowSuccessAlert] = useState(false);
@@ -36,7 +46,9 @@ export function SignUp({TESTING_FLAG}: {TESTING_FLAG?: boolean}) {
       email,
       budget,
       password,
-      TESTING_FLAG
+      TESTING_FLAG,
+      TEST_AUTH,
+      TEST_MODEL
     );
     if (result) {
       setShowErrorAlert(true);

--- a/src/lib/data/auth_model.firebase.ts
+++ b/src/lib/data/auth_model.firebase.ts
@@ -6,24 +6,17 @@ import {
   browserLocalPersistence,
   Auth,
 } from 'firebase/auth';
-import {User, DataModel, Database} from '.';
+import {User, DataModel} from '.';
 import {IAuthModel} from './auth_model';
-import {auth, Collections} from 'lib/firebase';
+import {auth} from 'lib/firebase';
 import {cookies} from 'next/headers';
-import {decodeProtectedHeader, importX509, jwtVerify} from 'jose';
+import {verifyCookie} from 'lib/firebase/cookies';
 
 const AUTH_COOKIE_FIREBASE = 'AUTH_COOKIE_FIREBASE';
 const USER_ID_FIREBASE = 'USER_ID_FIREBASE';
 const USER_EMAIL_FIREBASE = 'USER_EMAIL_FIREBASE';
 
-// Constants used to verify cookies
-const GOOGLE_PUBLIC_KEY =
-  'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com';
-const PROJECT_ID = 'gbudget-324';
-const KEY_ISSUER = `https://securetoken.google.com/${PROJECT_ID}`;
-
 export class FirestoreAuthModel implements IAuthModel {
-  // private dm = new DataModel(Database);
   private auth: Auth;
   constructor(authFire: Auth = auth) {
     this.auth = authFire;
@@ -32,7 +25,7 @@ export class FirestoreAuthModel implements IAuthModel {
     email: string,
     password: string,
     user: User,
-    dm: DataModel = new DataModel(Database)
+    dm: DataModel
   ): Promise<void> {
     await setPersistence(this.auth, browserLocalPersistence);
     const res = await createUserWithEmailAndPassword(
@@ -40,7 +33,7 @@ export class FirestoreAuthModel implements IAuthModel {
       email,
       password
     );
-    await dm.database.addDocument(Collections.Users, user);
+    await dm.setUser(user);
     const idToken = await res.user.getIdToken(true);
     cookies().set(AUTH_COOKIE_FIREBASE, idToken);
     cookies().set(USER_ID_FIREBASE, res.user.uid!);
@@ -71,59 +64,8 @@ export class FirestoreAuthModel implements IAuthModel {
     const user = cookies().get(USER_ID_FIREBASE);
     // If cookies are unset or the verification fails, return an error
     if (session && user) {
-      return await this.verifyCookie(session.value, user.value);
+      return await verifyCookie(session.value, user.value);
     }
     return Promise.reject(new Error('no user signed in'));
   }
-  // verifyCookie checks that an auth cookie is valid and not expired
-  // https://firebase.google.com/docs/auth/admin/verify-id-tokens#verify_id_tokens_using_a_third-party_jwt_library
-  private async verifyCookie(session?: string, uid?: string): Promise<string> {
-    if (!session || !uid) {
-      return Promise.reject(new Error('no session cookie available'));
-    }
-    const keys = await fetchPublicKey(GOOGLE_PUBLIC_KEY);
-    try {
-      const header = decodeProtectedHeader(session);
-      const keyString = keys[header.kid!];
-      const key = await importX509(keyString, 'RS256');
-      const {payload} = await jwtVerify(session, key);
-      const now = Date.now() / 1000;
-      if (payload.exp! <= now) {
-        return Promise.reject(new Error('session cookie has expired'));
-      }
-      if (payload.aud !== PROJECT_ID) {
-        return Promise.reject(
-          new Error('session cookie contains invalid project id')
-        );
-      }
-      if (payload.iat! > now) {
-        return Promise.reject(
-          new Error('session cookie was issued in the future')
-        );
-      }
-      if (payload.iss! !== KEY_ISSUER) {
-        return Promise.reject(
-          new Error('session cookie contains invalid issuer')
-        );
-      }
-      if (payload.sub !== uid) {
-        return Promise.reject(
-          new Error('session cookie contains invalid user information')
-        );
-      }
-      return payload.email as string;
-    } catch (error) {
-      return Promise.reject(error);
-    }
-  }
-}
-
-// fetchPublicKey is a helper method intended to fetch google's public signing keys
-// to verify that firebase cookie was singed by googled
-//AI Acknowledgement: This function was written using ChatGPT
-async function fetchPublicKey(
-  address: string
-): Promise<{[key: string]: string}> {
-  const res = await fetch(address);
-  return await res.json();
 }

--- a/src/lib/data/auth_model.firebase.ts
+++ b/src/lib/data/auth_model.firebase.ts
@@ -1,17 +1,26 @@
 import {
   createUserWithEmailAndPassword,
-  getAuth,
   signInWithEmailAndPassword,
   signOut,
   setPersistence,
-  browserSessionPersistence,
-  onAuthStateChanged,
+  browserLocalPersistence,
   Auth,
-  deleteUser,
 } from 'firebase/auth';
 import {User, DataModel, Database} from '.';
 import {IAuthModel} from './auth_model';
 import {auth, Collections} from 'lib/firebase';
+import {cookies} from 'next/headers';
+import {decodeProtectedHeader, importX509, jwtVerify} from 'jose';
+
+const AUTH_COOKIE_FIREBASE = 'AUTH_COOKIE_FIREBASE';
+const USER_ID_FIREBASE = 'USER_ID_FIREBASE';
+const USER_EMAIL_FIREBASE = 'USER_EMAIL_FIREBASE';
+
+// Constants used to verify cookies
+const GOOGLE_PUBLIC_KEY =
+  'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com';
+const PROJECT_ID = 'gbudget-324';
+const KEY_ISSUER = `https://securetoken.google.com/${PROJECT_ID}`;
 
 export class FirestoreAuthModel implements IAuthModel {
   // private dm = new DataModel(Database);
@@ -25,18 +34,31 @@ export class FirestoreAuthModel implements IAuthModel {
     user: User,
     dm: DataModel = new DataModel(Database)
   ): Promise<void> {
-    await setPersistence(this.auth, browserSessionPersistence);
-    await createUserWithEmailAndPassword(this.auth, email, password);
+    await setPersistence(this.auth, browserLocalPersistence);
+    const res = await createUserWithEmailAndPassword(
+      this.auth,
+      email,
+      password
+    );
     await dm.database.addDocument(Collections.Users, user);
+    const idToken = await res.user.getIdToken(true);
+    cookies().set(AUTH_COOKIE_FIREBASE, idToken);
+    cookies().set(USER_ID_FIREBASE, res.user.uid!);
+    cookies().set(USER_EMAIL_FIREBASE, res.user.email!);
   }
 
   // add sessions
   async signIn(email: string, password: string): Promise<void> {
-    await setPersistence(this.auth, browserSessionPersistence);
-    await signInWithEmailAndPassword(this.auth, email, password);
+    await setPersistence(this.auth, browserLocalPersistence);
+    const res = await signInWithEmailAndPassword(this.auth, email, password);
+    const idToken = await res.user.getIdToken(true);
+    cookies().set(AUTH_COOKIE_FIREBASE, idToken);
+    cookies().set(USER_ID_FIREBASE, res.user.uid!);
   }
 
   async signOut(): Promise<void> {
+    cookies().delete(AUTH_COOKIE_FIREBASE);
+    cookies().delete(USER_ID_FIREBASE);
     try {
       await signOut(this.auth);
     } catch (error) {
@@ -45,23 +67,63 @@ export class FirestoreAuthModel implements IAuthModel {
   }
 
   async getSignedInUser(): Promise<string> {
-    await this.auth.authStateReady();
-    const user = this.auth.currentUser;
-    if (user && user.email) {
-      const email = user.email;
-      return email;
+    const session = cookies().get(AUTH_COOKIE_FIREBASE);
+    const user = cookies().get(USER_ID_FIREBASE);
+    // If cookies are unset or the verification fails, return an error
+    if (session && user) {
+      return await this.verifyCookie(session.value, user.value);
     }
     return Promise.reject(new Error('no user signed in'));
-    // return Promise.reject('failing');
   }
-
-  async getUser(): Promise<void> {
-    await onAuthStateChanged(this.auth, user => {
-      if (user !== null) {
-        return Promise.resolve();
-      } else {
-        return Promise.reject('no user1');
+  // verifyCookie checks that an auth cookie is valid and not expired
+  // https://firebase.google.com/docs/auth/admin/verify-id-tokens#verify_id_tokens_using_a_third-party_jwt_library
+  private async verifyCookie(session?: string, uid?: string): Promise<string> {
+    if (!session || !uid) {
+      return Promise.reject(new Error('no session cookie available'));
+    }
+    const keys = await fetchPublicKey(GOOGLE_PUBLIC_KEY);
+    try {
+      const header = decodeProtectedHeader(session);
+      const keyString = keys[header.kid!];
+      const key = await importX509(keyString, 'RS256');
+      const {payload} = await jwtVerify(session, key);
+      const now = Date.now() / 1000;
+      if (payload.exp! <= now) {
+        return Promise.reject(new Error('session cookie has expired'));
       }
-    });
+      if (payload.aud !== PROJECT_ID) {
+        return Promise.reject(
+          new Error('session cookie contains invalid project id')
+        );
+      }
+      if (payload.iat! > now) {
+        return Promise.reject(
+          new Error('session cookie was issued in the future')
+        );
+      }
+      if (payload.iss! !== KEY_ISSUER) {
+        return Promise.reject(
+          new Error('session cookie contains invalid issuer')
+        );
+      }
+      if (payload.sub !== uid) {
+        return Promise.reject(
+          new Error('session cookie contains invalid user information')
+        );
+      }
+      return payload.email as string;
+    } catch (error) {
+      return Promise.reject(error);
+    }
   }
+}
+
+// fetchPublicKey is a helper method intended to fetch google's public signing keys
+// to verify that firebase cookie was singed by googled
+//AI Acknowledgement: This function was written using ChatGPT
+async function fetchPublicKey(
+  address: string
+): Promise<{[key: string]: string}> {
+  const res = await fetch(address);
+  return await res.json();
 }

--- a/src/lib/data/data_loader.ts
+++ b/src/lib/data/data_loader.ts
@@ -1,10 +1,4 @@
 import {Budget, Item, User} from '.';
-import {
-  getAuth,
-  createUserWithEmailAndPassword,
-  signOut,
-  signInWithEmailAndPassword,
-} from 'firebase/auth';
 import {IDatabase} from './database';
 import {Collections} from '../firebase/config';
 import {Filter, Sort, Database} from './database';

--- a/src/lib/data/data_loader.ts
+++ b/src/lib/data/data_loader.ts
@@ -1,4 +1,4 @@
-import {Budget, Item, User} from '.';
+import {Budget, Item, User, StatusChange, Status} from '.';
 import {IDatabase} from './database';
 import {Collections} from '../firebase/config';
 import {Filter, Sort, Database} from './database';
@@ -88,7 +88,7 @@ export class DataModel {
 
       // Write changes to Firestore
       await this.addBudget(budget);
-      await this.updateUser(user);
+      await this.setUser(user);
     } catch (err) {
       return Promise.reject(err);
     }
@@ -117,13 +117,13 @@ export class DataModel {
       // Write changes to Firestore
       await this.database.addManyDocuments(Collections.Items, items);
       await this.addBudget(budget);
-      await this.updateUser(user);
+      await this.setUser(user);
     } catch (err) {
       return Promise.reject(err);
     }
   }
 
-  async updateUser(user: User): Promise<void> {
+  async setUser(user: User): Promise<void> {
     await this.database.addDocument(Collections.Users, user);
   }
 
@@ -147,3 +147,5 @@ export class DataModel {
     return this.database.addDocument(Collections.Items, item);
   }
 }
+
+export const DefaultModel = new DataModel(Database);

--- a/src/lib/firebase/cookies.ts
+++ b/src/lib/firebase/cookies.ts
@@ -1,0 +1,71 @@
+import {decodeJwt, decodeProtectedHeader, importX509, jwtVerify} from 'jose';
+// fetchPublicKey is a helper method intended to fetch google's public signing keys
+// to verify that firebase cookie was singed by google
+async function fetchPublicKey(
+  address: string
+): Promise<{[key: string]: string}> {
+  const res = await fetch(address);
+  return await res.json();
+}
+
+// Constants used to verify cookies
+const GOOGLE_PUBLIC_KEY =
+  'https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com';
+const PROJECT_ID = 'gbudget-324';
+const KEY_ISSUER = `https://securetoken.google.com/${PROJECT_ID}`;
+
+// verifyCookie checks that an auth cookie is valid and not expired
+// if succesfull, return the email for the verified user
+// https://firebase.google.com/docs/auth/admin/verify-id-tokens#verify_id_tokens_using_a_third-party_jwt_library
+export async function verifyCookie(
+  session?: string,
+  uid?: string
+): Promise<string> {
+  if (!session || !uid) {
+    return Promise.reject(new Error('no session cookie available'));
+  }
+  const keys = await fetchPublicKey(GOOGLE_PUBLIC_KEY);
+  try {
+    const header = decodeProtectedHeader(session);
+    const keyString = keys[header.kid!];
+    const key = await importX509(keyString, 'RS256');
+    const {payload} = await jwtVerify(session, key);
+    const now = Date.now() / 1000;
+    if (payload.exp! <= now) {
+      return Promise.reject(new Error('session cookie has expired'));
+    }
+    if (payload.aud !== PROJECT_ID) {
+      return Promise.reject(
+        new Error('session cookie contains invalid project id')
+      );
+    }
+    if (payload.iat! > now) {
+      return Promise.reject(
+        new Error('session cookie was issued in the future')
+      );
+    }
+    if (payload.iss! !== KEY_ISSUER) {
+      return Promise.reject(
+        new Error('session cookie contains invalid issuer')
+      );
+    }
+    if (payload.sub !== uid) {
+      return Promise.reject(
+        new Error('session cookie contains invalid user information')
+      );
+    }
+    return payload.email as string;
+  } catch (error) {
+    return Promise.reject(error);
+  }
+}
+
+// decodeCookies returns the email from a firebase auth cookie WITHOUT verifiying
+// for testing only
+export async function decodeCookie(session?: string): Promise<string> {
+  if (!session) {
+    return Promise.reject(new Error('no session cookie available'));
+  }
+  const payload = decodeJwt(session);
+  return payload.email as string;
+}

--- a/test/app/auth.test.tsx
+++ b/test/app/auth.test.tsx
@@ -3,21 +3,19 @@ import {expect, describe, it, assert} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {userEvent} from '@testing-library/user-event';
 import {DataModel, User} from 'lib/data';
-import {getFirestore} from 'firebase/firestore';
-import {getLocalAuth, getLocalFirebase} from '../utils/database.util';
-import {FirestoreAuthModel} from 'lib/data/auth_model.firebase';
 import {deterUserType} from 'app/auth';
+import {MockAuthModel} from '../utils/authmodel.local';
+import {LocalDatabase} from '../utils/database.local';
+import {beforeEach} from 'vitest';
 
-const db = getFirestore();
-const database = getLocalFirebase(db);
+const database = new LocalDatabase();
 const dataModel = new DataModel(database);
 
-const auth = getLocalAuth();
-const authModel = new FirestoreAuthModel(auth);
+const authModel = new MockAuthModel();
 const testUsers: User[] = [1, 2, 3].map(number => {
   return {
-    id: `test_user_fe${number * 2}@studentorg.grinnell.edu`,
-    name: `test_user_fe${number * 2}`,
+    id: `test_user_fe${number}@studentorg.grinnell.edu`,
+    name: `test_user_fe${number}`,
     total_budget: 2000,
     remaining_budget: 1000,
     pending_event: 5,
@@ -26,10 +24,11 @@ const testUsers: User[] = [1, 2, 3].map(number => {
     user_type: 'RSO',
   };
 });
+
 const testUsersSEPC: User[] = [1, 2, 3].map(number => {
   return {
-    id: `test_user_fe${number * 2}_sepc@grinnell.edu`,
-    name: `test_user_fe${number * 2}`,
+    id: `test_user_fe${number}_sepc@grinnell.edu`,
+    name: `test_user_fe${number}`,
     total_budget: 2000,
     remaining_budget: 1000,
     pending_event: 5,
@@ -40,17 +39,19 @@ const testUsersSEPC: User[] = [1, 2, 3].map(number => {
 });
 
 function generateTestPassword(user: User) {
-  const password = `${user.id} + ${Math.floor(
-    Math.random() * user.total_budget
-  )}`;
+  const password = `${Math.random() * user.total_budget}`;
   return password;
 }
 
 const passwords: string[] = testUsers.map(user => {
   return generateTestPassword(user);
 });
-const passwordsse: string[] = testUsersSEPC.map(user => {
+const passwordsSEPC: string[] = testUsersSEPC.map(user => {
   return generateTestPassword(user);
+});
+
+beforeEach(() => {
+  authModel.signOut();
 });
 
 describe('Test Login works as Expected', async () => {
@@ -62,7 +63,9 @@ describe('Test Login works as Expected', async () => {
       dataModel
     );
     const user = userEvent.setup();
-    render(<LogIn TESTING_FLAG={true} />);
+    render(
+      <LogIn TESTING_FLAG={true} TEST_MODEL={dataModel} TEST_AUTH={authModel} />
+    );
     expect(screen.queryByTestId('login-form')).toBeInTheDocument();
     expect(screen.queryByTestId('sign-up-form-button')).toBeInTheDocument();
     const formInputs = await screen.findAllByTestId(/login-form/);
@@ -81,9 +84,12 @@ describe('Test Login works as Expected', async () => {
     assert.equal(userId, testUsers[0].id);
     await authModel.signOut();
   });
+
   it('render login form to log in but fail with bad credentials', async () => {
     const user = userEvent.setup();
-    render(<LogIn TESTING_FLAG={true} />);
+    render(
+      <LogIn TESTING_FLAG={true} TEST_MODEL={dataModel} TEST_AUTH={authModel} />
+    );
     expect(screen.queryByTestId('login-form')).toBeInTheDocument();
     expect(screen.queryByTestId('sign-up-form-button')).toBeInTheDocument();
     const formInputs = await screen.findAllByTestId(/login-form/);
@@ -99,25 +105,34 @@ describe('Test Login works as Expected', async () => {
 
     expect(await screen.findByText('Sign In Failed:', {exact: false}));
   });
+
   it('render login form to create account with correct type RSO', async () => {
     const user = userEvent.setup();
-    render(<LogIn TESTING_FLAG={true} />);
+    render(
+      <LogIn TESTING_FLAG={true} TEST_MODEL={dataModel} TEST_AUTH={authModel} />
+    );
+
     expect(screen.queryByTestId('login-form')).toBeInTheDocument();
     expect(screen.queryByTestId('sign-up-form-button')).toBeInTheDocument();
+
     await user.click(screen.getByTestId('sign-up-form-button'));
+
     const formInputs = await screen.findAllByTestId(/sign-up-form/);
     formInputs.forEach(element => expect(element).toBeVisible());
 
+    const nameInput = await screen.findByTestId('sign-up-form-name');
     const emailInput = await screen.findByTestId('sign-up-form-email');
     const passwordInput = await screen.findByTestId('sign-up-form-password');
-    const nameInput = await screen.findByTestId('sign-up-form-name');
     const budgetInput = await screen.findByTestId('sign-up-form-budget');
+
     const submitButton = await screen.findByTestId('sign-up-form-submit');
 
     await user.type(emailInput, testUsers[1].id);
     await user.type(passwordInput, passwords[1]);
     await user.type(nameInput, testUsers[1].name);
     await user.type(budgetInput, testUsers[1].total_budget.toString());
+
+    await user.click(submitButton);
     await user.click(submitButton);
 
     const user1 = await dataModel.getUser(testUsers[1].id);
@@ -132,7 +147,9 @@ describe('Test Login works as Expected', async () => {
   });
   it('render login form to create account with correct type SEPC', async () => {
     const user = userEvent.setup();
-    render(<LogIn TESTING_FLAG={true} />);
+    render(
+      <LogIn TESTING_FLAG={true} TEST_MODEL={dataModel} TEST_AUTH={authModel} />
+    );
     expect(screen.queryByTestId('login-form')).toBeInTheDocument();
     expect(screen.queryByTestId('sign-up-form-button')).toBeInTheDocument();
     await user.click(screen.getByTestId('sign-up-form-button'));
@@ -146,7 +163,7 @@ describe('Test Login works as Expected', async () => {
     const submitButton = await screen.findByTestId('sign-up-form-submit');
 
     await user.type(emailInput, testUsersSEPC[0].id);
-    await user.type(passwordInput, passwordsse[0]);
+    await user.type(passwordInput, passwordsSEPC[0]);
     await user.type(nameInput, testUsersSEPC[0].name);
     await user.type(budgetInput, testUsersSEPC[0].total_budget.toString());
     await user.click(submitButton);
@@ -164,7 +181,9 @@ describe('Test Login works as Expected', async () => {
   });
   it('create account should fail with bad email type', async () => {
     const user = userEvent.setup();
-    render(<LogIn TESTING_FLAG={true} />);
+    render(
+      <LogIn TESTING_FLAG={true} TEST_MODEL={dataModel} TEST_AUTH={authModel} />
+    );
     expect(screen.queryByTestId('login-form')).toBeInTheDocument();
     expect(screen.queryByTestId('sign-up-form-button')).toBeInTheDocument();
     await user.click(screen.getByTestId('sign-up-form-button'));
@@ -187,7 +206,9 @@ describe('Test Login works as Expected', async () => {
   });
   it('render login form with empty create account form', async () => {
     const user = userEvent.setup();
-    render(<LogIn TESTING_FLAG={true} />);
+    render(
+      <LogIn TESTING_FLAG={true} TEST_MODEL={dataModel} TEST_AUTH={authModel} />
+    );
     expect(screen.queryByTestId('login-form')).toBeInTheDocument();
     expect(screen.queryByTestId('sign-up-form-button')).toBeInTheDocument();
     await user.click(screen.getByTestId('sign-up-form-button'));
@@ -196,38 +217,22 @@ describe('Test Login works as Expected', async () => {
 
     const emailInput = await screen.findByTestId('sign-up-form-email');
     const passwordInput = await screen.findByTestId('sign-up-form-password');
-    // const nameInput = await screen.findByTestId('sign-up-form-name');
-    // const budgetInput = await screen.findByTestId('sign-up-form-budget');
-    // const typeInput = await screen.findByTestId('sign-up-form-input-user_type');
     const submitButton = await screen.findByTestId('sign-up-form-submit');
 
     await user.type(emailInput, testUsers[2].id);
     await user.type(passwordInput, passwords[2]);
-    // await user.type(nameInput, testUsers[1].name);
-    // await user.type(budgetInput, testUsers[1].total_budget.toString());
-    // await user.selectOptions(typeInput, testUsers[1].user_type);
     await user.click(submitButton);
     await user.click(submitButton);
 
-    try {
-      await authModel.signIn(testUsers[2].id, passwords[2]);
-      assert.fail('Sign In fails');
-    } catch (error) {
-      if (error instanceof Error) {
-        assert.equal(
-          error.message,
-          'Firebase: Error (auth/user-not-found).',
-          'Expected error message not received'
-        );
-      } else {
-        assert.fail('Caught an error, but it is not an instance of Error');
-      }
-    }
+    await expect(
+      async () => await authModel.signIn(testUsers[2].id, passwords[2])
+    ).rejects.toThrowError();
 
     await expect(
       async () => await authModel.getSignedInUser()
     ).rejects.toThrowError();
   });
+
   it('Ensure usertype parse works for create user', async () => {
     const type = await deterUserType('sgatreasurer@grinnell.edu');
     assert.equal(type, 'SGA_Treasurer');

--- a/test/lib/auth/authmodel.local.test.ts
+++ b/test/lib/auth/authmodel.local.test.ts
@@ -10,30 +10,6 @@ import {Collections} from 'lib/firebase';
 import {getFirestore} from 'firebase/firestore';
 import {FirestoreAuthModel} from 'lib/data/auth_model.firebase';
 
-vi.mock('next/headers', async () => {
-  const cookiesMap: Record<string, string> = {};
-
-  return {
-    cookies: () => {
-      return {
-        get: (name: string) => {
-          return {
-            value: cookiesMap[name] || '',
-          };
-        },
-        set: (name: string, value: string) => {
-          cookiesMap[name] = value;
-        },
-        delete: (name: string) => {
-          delete cookiesMap[name];
-        },
-      };
-    },
-  };
-});
-
-// const testCollection = Collections.Users;
-// const database = new LocalDatabase();
 const db = getFirestore();
 const database = getLocalFirebase(db);
 const dataModel = new DataModel(database);
@@ -132,7 +108,6 @@ describe('Test FirestoreAuthModel class', async () => {
 
     try {
       await authModel.signIn(testUsers[3].id, passwords[2]);
-      assert.fail('Sign In fails');
     } catch (error) {
       if (error instanceof Error) {
         assert.equal(
@@ -154,7 +129,6 @@ describe('Test FirestoreAuthModel class', async () => {
         testUsers[2],
         dataModel
       );
-      assert.fail('Create user fails');
     } catch (error) {
       if (error instanceof Error) {
         assert.equal(

--- a/test/lib/auth/authmodel.local.test.ts
+++ b/test/lib/auth/authmodel.local.test.ts
@@ -1,5 +1,5 @@
 import {DataModel, User} from 'lib/data';
-import {beforeEach, describe, expect, test, assert, vi} from 'vitest';
+import {beforeEach, describe, expect, test, assert} from 'vitest';
 import {
   clearAuthUsers,
   clearCollection,

--- a/test/lib/data/addBudget.firebase.test.ts
+++ b/test/lib/data/addBudget.firebase.test.ts
@@ -1,82 +1,38 @@
 import {assert, beforeAll, it, describe, expect} from 'vitest';
-import {getFirestore} from 'firebase/firestore';
 import {Budget, DataModel, User} from 'lib/data';
 import {Collections} from 'lib/firebase';
 import {getLocalFirebase} from '../../utils/database.util';
+import {defaultTestUser, defaultTestBudget} from '../../utils/defaults';
 
-const db = getFirestore();
-const database = getLocalFirebase(db);
+const database = getLocalFirebase();
 
 beforeAll(async () => {
-  const testUser: User[] = [1, 2, 3].map(number => {
+  const testUsers: User[] = [1, 2, 3].map(number => {
     return {
+      ...defaultTestUser,
       id: `test_user${number}`,
-      total_budget: 2000,
-      remaining_budget: 1000,
-      pending_event: 10,
-      completed_event: 10,
-      planned_event: 10,
-      user_name: 'test_user1',
-      user_type: 'RSO',
     };
-  });
-
-  testUser.push({
-    id: 'test_user4',
-    total_budget: 1000,
-    remaining_budget: 200,
-    pending_event: 5,
-    completed_event: 5,
-    planned_event: 0,
-    user_name: 'test_user1',
-    user_type: 'SEPC',
   });
 
   const testBudget: Budget[] = [1, 2, 3].map(number => {
     return {
+      ...defaultTestBudget,
       id: `budget_${number}`,
       user_id: `test_user${number}`,
-      event_name: `event_name_${number}`,
-      event_description: 'test description',
-      total_cost: number * 100,
-      current_status: 'created',
-      status_history: [
-        {
-          status: 'created',
-          when: new Date('2001-01-01').toISOString(),
-        },
-      ],
-      items: [],
     };
   });
 
-  testBudget.push({
-    id: 'budget_user_4',
-    user_id: 'test_user4',
-    event_name: 'event_name',
-    event_description: 'test description',
-    total_cost: 100,
-    current_status: 'created',
-    status_history: [
-      {
-        status: 'created',
-        when: new Date('2001-01-01').toISOString(),
-      },
-    ],
-    items: [],
-  });
-
-  await database.addManyDocuments(Collections.Users, testUser);
+  await database.addManyDocuments(Collections.Users, testUsers);
   await database.addManyDocuments(Collections.Budgets, testBudget);
 });
 
 describe('test addBudget', () => {
   const dataModel = new DataModel(database);
   it('should increment planned_event by 1 and add the budget if user exists', async () => {
-    const user = await dataModel.getUser('test_user4');
-    const budgetToAdd = await dataModel.getBudget('budget_user_4');
+    const user = await dataModel.getUser('test_user3');
+    const budgetToAdd = await dataModel.getBudget('budget_3');
     await dataModel.addBudget(budgetToAdd);
-    const updatedUser = await dataModel.getUser('test_user4');
+    const updatedUser = await dataModel.getUser('test_user3');
     expect(updatedUser.planned_event).toEqual(user.planned_event + 1);
   });
 });
@@ -87,6 +43,7 @@ describe('test addBudget 2', async () => {
     const budgetToAddError: Budget = {
       id: 'test_error',
       user_id: 'user_error',
+      user_name: 'user_error',
       event_name: 'error_event',
       event_description: 'error_description',
       event_datetime: 'error_000',

--- a/test/lib/data/changestatus.test.ts
+++ b/test/lib/data/changestatus.test.ts
@@ -1,8 +1,8 @@
-import {assert, beforeAll, it, describe, expect} from 'vitest';
+import {beforeAll, it, describe, expect} from 'vitest';
 import {getFirestore} from 'firebase/firestore';
-import {Budget, DataModel, Item, User} from 'lib/data';
+import {Budget, DataModel, Item} from 'lib/data';
 import {Collections} from 'lib/firebase';
-import {getLocalFirebase, clearCollection} from '../../utils/database.util';
+import {getLocalFirebase} from '../../utils/database.util';
 
 const db = getFirestore();
 const database = getLocalFirebase(db);

--- a/test/lib/data/getbudget.firebase.test.ts
+++ b/test/lib/data/getbudget.firebase.test.ts
@@ -2,15 +2,18 @@ import {assert, beforeAll, it, describe, expect, test} from 'vitest';
 import {Budget, DataModel} from 'lib/data';
 import {getLocalFirebase} from '../../utils/database.util';
 import {Collections} from 'lib/firebase';
+import {getFirestore, waitForPendingWrites} from 'firebase/firestore';
+import {defaultTestBudget} from '../../utils/defaults';
 
-const database = getLocalFirebase();
+const db = getFirestore();
+const database = getLocalFirebase(db);
 
 beforeAll(async () => {
   const testBudgets: Budget[] = [1, 2, 3].map(number => {
     return {
-      id: `budget_${number}`,
-      user_id: 'user_1',
-      user_name: 'user_1',
+      ...defaultTestBudget,
+      id: `get_budget_test_budget_${number}`,
+      user_id: 'get_budget_test_user_1',
       event_name: `event_name_${number}`,
       event_description: 'test description',
       total_cost: number * 100,
@@ -27,37 +30,26 @@ beforeAll(async () => {
   });
 
   testBudgets.push({
-    id: 'budget_user_2',
-    user_id: 'user_2',
-    user_name: 'test user',
-    event_name: 'event_name',
-    event_description: 'test description',
-    total_cost: 100,
-    current_status: 'created',
-    status_history: [
-      {
-        status: 'created',
-        when: new Date('2001-01-01').toISOString(),
-      },
-    ],
-    items: [],
-    event_type: 'Other',
+    ...defaultTestBudget,
+    id: 'get_budget_test_user_2',
+    user_id: 'get_budget_test_user_2',
   });
 
   await database.addManyDocuments(Collections.Budgets, testBudgets);
+  await waitForPendingWrites(db);
 });
 
 describe('test firebase getBudget', async () => {
   // dummy budgets for testing the getBudget function
   const dataModel = new DataModel(database);
   it('function gets correct budget', async () => {
-    const budget = await dataModel.getBudget('budget_1');
-    assert.equal(budget!.id, 'budget_1');
+    const budget = await dataModel.getBudget('get_budget_test_budget_1');
+    assert.equal(budget!.id, 'get_budget_test_budget_1');
   });
 
   it('function errors on nonexistent budget', async () => {
     await expect(
-      async () => await dataModel.getBudget('budget_5')
+      async () => await dataModel.getBudget('get_budget_test_budget_5')
     ).rejects.toThrowError();
   });
 });
@@ -65,16 +57,16 @@ describe('test firebase getBudget', async () => {
 describe('test getBudetsForUser', async () => {
   const dataModel = new DataModel(database);
   test('function gets all correct budgets user 1', async () => {
-    const budgets = await dataModel.getBudgetsForUser('user_1');
+    const budgets = await dataModel.getBudgetsForUser('get_budget_test_user_1');
     assert.equal(
       budgets.length,
       3,
-      `user_1 has 3 budgets but call returned ${budgets.length}`
+      `get_budget_test_user_1 has 3 budgets but call returned ${budgets.length}`
     );
   });
 
   test('function gets all correct budgets user 2', async () => {
-    const budgets = await dataModel.getBudgetsForUser('user_2');
+    const budgets = await dataModel.getBudgetsForUser('get_budget_test_user_2');
     assert.equal(
       budgets.length,
       1,

--- a/test/lib/data/getbudget.firebase.test.ts
+++ b/test/lib/data/getbudget.firebase.test.ts
@@ -1,11 +1,9 @@
 import {assert, beforeAll, it, describe, expect, test} from 'vitest';
-import {getFirestore} from 'firebase/firestore';
 import {Budget, DataModel} from 'lib/data';
 import {getLocalFirebase} from '../../utils/database.util';
 import {Collections} from 'lib/firebase';
 
-const db = getFirestore();
-const database = getLocalFirebase(db);
+const database = getLocalFirebase();
 
 beforeAll(async () => {
   const testBudgets: Budget[] = [1, 2, 3].map(number => {

--- a/test/lib/data/items_loader.firebase.test.ts
+++ b/test/lib/data/items_loader.firebase.test.ts
@@ -23,6 +23,7 @@ beforeAll(async () => {
   const testBudget: Budget = {
     id: 'test_budget_for_items',
     user_id: 'user_items', // the user this budget belongs to
+    user_name: 'user_item',
     event_name: 'test_for_items',
     event_description: 'test_for_items',
     total_cost: 10.0 * 3 * 2,
@@ -35,6 +36,7 @@ beforeAll(async () => {
   const addItemTestBudget: Budget = {
     id: 'test_budget_for_add_items',
     user_id: 'user_items', // the user this budget belongs to
+    user_name: 'user_item',
     event_name: 'test_for_add_items',
     event_description: 'test_for_add_items',
     total_cost: 0,
@@ -46,7 +48,7 @@ beforeAll(async () => {
 
   const testUser: User = {
     id: 'user_items',
-    user_name: 'user_items',
+    name: 'user_items',
     remaining_budget: 500,
     total_budget: 500,
     pending_event: 1,

--- a/test/lib/data/items_loader.firebase.test.ts
+++ b/test/lib/data/items_loader.firebase.test.ts
@@ -1,71 +1,50 @@
 import {assert, beforeAll, it, describe} from 'vitest';
 import {Budget, Item, Sort, DataModel, User} from 'lib/data';
-import {getFirestore} from 'firebase/firestore';
 import {getLocalFirebase} from '../../utils/database.util';
 import {Collections} from 'lib/firebase';
+import {
+  defaultTestBudget,
+  defaultTestItem,
+  defaultTestUser,
+} from '../../utils/defaults';
 
-const db = getFirestore();
-const database = getLocalFirebase(db);
+const database = getLocalFirebase();
+const dataModel = new DataModel(database);
+
 beforeAll(async () => {
   const testItems: Item[] = [1, 2, 3].map(number => {
     return {
+      ...defaultTestItem,
       budget_id: 'test_budget_for_items',
-      unit_price: 10.0,
       id: `item_${number}`,
-      name: `testing item ${number}`,
-      quantity: 2,
-      rso_item_comment: null,
-      sga_item_comment: null,
-      url: 'test',
-      vendor: 'test',
     };
   });
   const testBudget: Budget = {
+    ...defaultTestBudget,
     id: 'test_budget_for_items',
     user_id: 'user_items', // the user this budget belongs to
-    user_name: 'user_item',
-    event_name: 'test_for_items',
-    event_description: 'test_for_items',
-    total_cost: 10.0 * 3 * 2,
-    current_status: 'created',
-    status_history: [],
-    items: [],
-    event_type: 'Harris',
   };
 
   const addItemTestBudget: Budget = {
+    ...defaultTestBudget,
     id: 'test_budget_for_add_items',
     user_id: 'user_items', // the user this budget belongs to
-    user_name: 'user_item',
-    event_name: 'test_for_add_items',
-    event_description: 'test_for_add_items',
-    total_cost: 0,
-    current_status: 'created',
-    status_history: [],
-    items: [],
-    event_type: 'Harris',
   };
 
   const testUser: User = {
+    ...defaultTestUser,
     id: 'user_items',
-    name: 'user_items',
     remaining_budget: 500,
     total_budget: 500,
-    pending_event: 1,
-    planned_event: 1,
-    completed_event: 1,
-    user_type: 'SEPC',
   };
 
-  database.addManyDocuments(Collections.Items, testItems);
-  database.addDocument(Collections.Budgets, testBudget);
-  database.addDocument(Collections.Budgets, addItemTestBudget);
-  database.addDocument(Collections.Users, testUser);
+  await dataModel.setUser(testUser);
+  await dataModel.addBudget(testBudget);
+  await dataModel.addBudget(addItemTestBudget);
+  await database.addManyDocuments(Collections.Items, testItems);
 });
 
 describe('Test getBudgetItems', async () => {
-  const dataModel = new DataModel(database);
-
   it('function gets all correct budgets user_1', async () => {
     const items: Item[] = await dataModel.getItemsForBudget(
       'test_budget_for_items',
@@ -91,19 +70,11 @@ describe('Test getBudgetItems', async () => {
 });
 
 describe('Test addItem and addItems', async () => {
-  const dataModel = new DataModel(database);
-
   it('addItem correctly adds one item to a budget', async () => {
     const item: Item = {
+      ...defaultTestItem,
       budget_id: 'test_budget_for_add_items',
-      unit_price: 10.0,
       id: 'test_additem',
-      name: 'testing additem',
-      quantity: 2,
-      rso_item_comment: null,
-      sga_item_comment: null,
-      url: 'test',
-      vendor: 'test',
     };
     await dataModel.addItem(item);
     const test_budget_upd = await dataModel.getBudget(
@@ -117,18 +88,15 @@ describe('Test addItem and addItems', async () => {
 
     assert.deepEqual(items.pop(), item);
   });
+
   it('addItems correctly adds items to a budget', async () => {
     const items: Item[] = [1, 2, 3].map(number => {
       return {
+        ...defaultTestItem,
+        id: `item_add_item${number}`,
         budget_id: 'test_budget_for_add_items',
         unit_price: 10.0,
-        id: `item_add_item${number}`,
-        name: `testing add_item ${number}`,
         quantity: 2,
-        rso_item_comment: null,
-        sga_item_comment: null,
-        url: 'test',
-        vendor: 'test',
       };
     });
     await dataModel.addItems(items);

--- a/test/utils/authmodel.local.ts
+++ b/test/utils/authmodel.local.ts
@@ -1,0 +1,47 @@
+import {User} from 'lib/data'; // Assuming User interface is defined elsewhere
+import {DataModel} from 'lib/data';
+import {IAuthModel} from 'lib/data/auth_model';
+
+export class MockAuthModel implements IAuthModel {
+  private users: Map<string, string> = new Map(); // Map to store users by email
+  private signedInUser: string | null = null;
+
+  async createUser(
+    email: string,
+    password: string,
+    user: User,
+    dm: DataModel
+  ): Promise<void> {
+    // Simulate creating a user in a database
+    if (this.users.has(email)) {
+      throw new Error('User already exists');
+    }
+    await dm.setUser(user);
+    this.users.set(email, password);
+    this.signedInUser = email;
+  }
+
+  async signIn(email: string, password: string): Promise<void> {
+    // Simulate signing in by checking credentials (in a real scenario, this would interact with a database)
+    const userPassword = this.users.get(email);
+    if (userPassword && userPassword === password) {
+      this.signedInUser = email;
+    } else {
+      throw new Error('Invalid credentials');
+    }
+  }
+
+  async signOut(): Promise<void> {
+    // Simulate signing out by resetting the signed-in user
+    this.signedInUser = null;
+  }
+
+  async getSignedInUser(): Promise<string> {
+    // Return the signed-in user (if any)
+    if (this.signedInUser) {
+      return this.signedInUser;
+    } else {
+      throw new Error('No user signed in');
+    }
+  }
+}

--- a/test/utils/database.util.ts
+++ b/test/utils/database.util.ts
@@ -1,8 +1,12 @@
 import {Document, FirestoreDatabase, IDatabase} from 'lib/data';
-import {Firestore, connectFirestoreEmulator} from 'firebase/firestore';
-import {connectAuthEmulator, Auth, getAuth} from 'firebase/auth';
+import {
+  Firestore,
+  connectFirestoreEmulator,
+  getFirestore,
+} from 'firebase/firestore';
+import {connectAuthEmulator, getAuth} from 'firebase/auth';
 
-export function getLocalFirebase(db: Firestore): IDatabase {
+export function getLocalFirebase(db: Firestore = getFirestore()): IDatabase {
   connectFirestoreEmulator(db, 'localhost', 3240);
   return new FirestoreDatabase(db);
 }
@@ -19,4 +23,19 @@ export async function clearCollection(database: IDatabase, collection: string) {
   docs.forEach(async (doc: Document) => {
     await database.deleteDocument(collection, doc);
   });
+}
+
+export async function clearAuthUsers(projectID = 'demo', port = 9099) {
+  const url = `http://localhost:${port}/emulator/v1/projects/${projectID}/accounts`;
+  const options = {
+    method: 'DELETE',
+    headers: {
+      Authorization: 'Bearer owner',
+    },
+  };
+  const res = await fetch(url, options);
+  if (!res.ok)
+    return Promise.reject(
+      new Error(`couldn't clear users; got response \n ${await res.json()}`)
+    );
 }

--- a/test/utils/database.util.ts
+++ b/test/utils/database.util.ts
@@ -1,3 +1,4 @@
+import {vi} from 'vitest';
 import {Document, FirestoreDatabase, IDatabase} from 'lib/data';
 import {
   Firestore,
@@ -5,6 +6,7 @@ import {
   getFirestore,
 } from 'firebase/firestore';
 import {connectAuthEmulator, getAuth} from 'firebase/auth';
+import {decodeCookie} from 'lib/firebase/cookies';
 
 export function getLocalFirebase(db: Firestore = getFirestore()): IDatabase {
   connectFirestoreEmulator(db, 'localhost', 3240);
@@ -12,6 +14,37 @@ export function getLocalFirebase(db: Firestore = getFirestore()): IDatabase {
 }
 
 export function getLocalAuth() {
+  // Mock cookie verification so no network calls are made
+  vi.mock('lib/firebase/cookies', async importOriginal => {
+    const mod = await importOriginal<typeof import('lib/firebase/cookies')>();
+    return {
+      ...mod,
+      // replace some exports
+      verifyCookie: (session?: string, uid?: string) => decodeCookie(session),
+    };
+  });
+
+  // Mock cookies api so cookies can be used when testing auth
+  vi.mock('next/headers', async () => {
+    const cookiesMap: Record<string, string> = {};
+    return {
+      cookies: () => {
+        return {
+          get: (name: string) => {
+            return {
+              value: cookiesMap[name] || '',
+            };
+          },
+          set: (name: string, value: string) => {
+            cookiesMap[name] = value;
+          },
+          delete: (name: string) => {
+            delete cookiesMap[name];
+          },
+        };
+      },
+    };
+  });
   const auth = getAuth();
   connectAuthEmulator(auth, 'http://localhost:9099');
   return auth;

--- a/test/utils/defaults.ts
+++ b/test/utils/defaults.ts
@@ -1,0 +1,42 @@
+import {User, Budget, Item} from 'lib/data';
+
+// This file exists so tests can reuse these fake mock types
+// whenever updating data types, we can change them here so tests don't break
+export const defaultTestUser: User = {
+  id: 'test_user',
+  total_budget: 2000,
+  remaining_budget: 2000,
+  pending_event: 1,
+  completed_event: 1,
+  planned_event: 1,
+  name: 'test_user',
+  user_type: 'RSO',
+};
+
+export const defaultTestBudget: Budget = {
+  id: 'test_budget',
+  user_id: 'test_user',
+  user_name: 'test_user',
+  event_name: 'event_name',
+  event_description: 'test description',
+  event_type: 'Food',
+  total_cost: 0,
+  current_status: 'created',
+  status_history: [
+    {
+      status: 'created',
+      when: new Date('2001-01-01').toISOString(),
+    },
+  ],
+};
+
+export const defaultTestItem: Item = {
+  budget_id: 'test_budget_for_items',
+  unit_price: 10,
+  id: 'test_item',
+  name: 'testing item',
+  quantity: 2,
+  current_status: 'created',
+  url: 'test',
+  vendor: 'test',
+};

--- a/test/utils/defaults.ts
+++ b/test/utils/defaults.ts
@@ -6,9 +6,9 @@ export const defaultTestUser: User = {
   id: 'test_user',
   total_budget: 2000,
   remaining_budget: 2000,
-  pending_event: 1,
-  completed_event: 1,
-  planned_event: 1,
+  pending_event: 0,
+  completed_event: 0,
+  planned_event: 0,
   name: 'test_user',
   user_type: 'RSO',
 };


### PR DESCRIPTION
## Why / Feature

- Add cookie setting to the firebase auth model so signing works; cookies are verified using firebase public keys to make sure they are authentic



## What's Changed in the Code

- In the firebase auth model, the various authentication functions now set and unset cookies appropriately
- created a new file cookies.ts in the firebase folder for decrypting and verifying cookies from firebase 

- Add some new features to help improve test code hygiene such as
  - fetching local emulator now automatically mocks cookies setting and getting as well as the decoding using firebase to avoid network calls
  - created a new test/utils/default.ts with default items, budgets and users. some tests now use these to generate fake data for testing; this approach gives us one place to change our data types when our code changes without breaking tests
  - change tests to use LocalDatabase instead of the emulator since the emulator is very buggy when possible

- Changed authentication FE to take mock data and auth models for testing


## How can I check if it works?

- Try various authentication patterns such as singing in, creating a user, signing out and so on

## How did I test?

- Fixed unit tests to check various features